### PR TITLE
build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist/
+out/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # texture-tools
 texture tools to help extract textures from images.
+
+## Building
+In order to build `texture-tools`, make sure you have [Node.js](https://nodejs.org/) (version 14 minimum) installed.
+
+clone the repo
+```
+git clone https://github.com/therealturkey/texture-tools.git
+```
+
+install the dependencies
+```
+npm install
+```
+
+run the following command to compile the TypeScript code into Javascript.
+```
+npm run build
+```
+
+or alternatively, run this following command to both compile and start the development build.
+```
+npm run start
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "texture-tools",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "electron": "^15.3.0"
       }


### PR DESCRIPTION
also fixed the license in package-lock.json and gitignored the `out` directory in preparation for packaging 